### PR TITLE
:up: Better cursor positioning

### DIFF
--- a/.gut-config.json
+++ b/.gut-config.json
@@ -1,0 +1,5 @@
+{
+  "_DESCRIPTION": "This file is used by https://github.com/quilicicf/Gut to help developers interact with git",
+  "commitMessageSuffixTemplate": "#$ticketNumber",
+  "reviewTool": "github"
+}

--- a/lib/computeOffsetFromPosition.js
+++ b/lib/computeOffsetFromPosition.js
@@ -1,0 +1,25 @@
+module.exports = (cursorPosition, fileContent) => {
+  const positionFinder = fileContent
+    .split('\n')
+    .reduce(
+      (seed, line) => {
+        if (seed.rowNumber < cursorPosition.row) {
+          return {
+            offset: seed.offset + line.length + 1, // Trailing line break
+            rowNumber: seed.rowNumber + 1,
+          };
+        }
+
+        if (seed.rowNumber === cursorPosition.row) {
+          return {
+            offset: seed.offset + cursorPosition.column,
+            rowNumber: seed.rowNumber + 1,
+          };
+        }
+
+        return seed;
+      },
+      { offset: 0, rowNumber: 1 },
+    );
+  return positionFinder.offset;
+};

--- a/lib/formatEditorContent.js
+++ b/lib/formatEditorContent.js
@@ -1,5 +1,7 @@
 'use babel';
 
+import computeOffsetFromPosition from './computeOffsetFromPosition';
+
 let formatFromString;
 
 /**
@@ -12,6 +14,11 @@ const loadFormatFromString = () => {
 };
 
 export default async (editor) => {
-  const formattedMarkdown = await loadFormatFromString()(editor.getText());
-  editor.setText(formattedMarkdown);
+  const oldCursorPosition = editor.getCursors()[ 0 ].getBufferPosition();
+  const oldCursorOffset = computeOffsetFromPosition(oldCursorPosition, editor.getText());
+
+  const { contents, newCursorPosition } = await loadFormatFromString()(editor.getText(), oldCursorOffset);
+  const { line, column } = newCursorPosition;
+  editor.getBuffer().setTextViaDiff(contents);
+  editor.setCursorBufferPosition([ line, column ]);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -108,9 +108,9 @@
       }
     },
     "@quilicicf/markdown-formatter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@quilicicf/markdown-formatter/-/markdown-formatter-1.0.0.tgz",
-      "integrity": "sha512-nu7KaoNbLYrjVvthhYXJHO/F7sgGXen4a/uQggmiih0iNfKoodVWRJXlWV04N8OZxbzqxmSZXUCFJg3f7aHZTg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@quilicicf/markdown-formatter/-/markdown-formatter-2.0.1.tgz",
+      "integrity": "sha512-+XuFnbLMUzKQKVvLxrPH040eppfqVSLZ9g9hJOWxMc65auLyVWfH3wH1M3hWR/lTUa3ABsoBPLyYKhjR0w5aHg==",
       "requires": {
         "is-valid-path": "0.1.1",
         "lodash": "4.17.11",
@@ -267,22 +267,22 @@
       }
     },
     "@types/node": {
-      "version": "10.12.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
-      "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ=="
+      "version": "11.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.9.4.tgz",
+      "integrity": "sha512-Zl8dGvAcEmadgs1tmSPcvwzO1YRsz38bVJQvH1RvRqSR9/5n61Q1ktcDL0ht3FXWR+ZpVmXVwN1LuH4Ax23NsA=="
     },
     "@types/unist": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.2.tgz",
-      "integrity": "sha512-iHI60IbyfQilNubmxsq4zqSjdynlmc2Q/QvH9kjzg9+CCYVVzq1O6tc7VBzSygIwnmOt07w80IG6HDQvjv3Liw=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
+      "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
     },
     "@types/vfile": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/vfile/-/vfile-3.0.2.tgz",
       "integrity": "sha512-b3nLFGaGkJ9rzOcuXRfHkZMdjsawuDD0ENL9fzTophtBg8FJHSGbH7daXkEpcwy3v7Xol3pAvsmlYyFhR4pqJw==",
       "requires": {
-        "@types/node": "10.12.18",
-        "@types/unist": "2.0.2",
+        "@types/node": "11.9.4",
+        "@types/unist": "2.0.3",
         "@types/vfile-message": "1.0.1"
       }
     },
@@ -291,8 +291,8 @@
       "resolved": "https://registry.npmjs.org/@types/vfile-message/-/vfile-message-1.0.1.tgz",
       "integrity": "sha512-mlGER3Aqmq7bqR1tTTIVHq8KSAFFRyGbrxuM8C/H82g6k7r2fS+IMEkIu3D7JHzG10NvPdR8DNx0jr0pwpp4dA==",
       "requires": {
-        "@types/node": "10.12.18",
-        "@types/unist": "2.0.2"
+        "@types/node": "11.9.4",
+        "@types/unist": "2.0.3"
       }
     },
     "acorn": {
@@ -1914,13 +1914,13 @@
       }
     },
     "mem": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-4.0.0.tgz",
-      "integrity": "sha512-WQxG/5xYc3tMbYLXoXPm81ET2WDULiU5FxbuIoNbJqLOOI8zehXFdZuiUEgfdrU2mVB1pxBZUGlYORSrpuJreA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-4.1.0.tgz",
+      "integrity": "sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==",
       "requires": {
         "map-age-cleaner": "0.1.3",
         "mimic-fn": "1.2.0",
-        "p-is-promise": "1.1.0"
+        "p-is-promise": "2.0.0"
       }
     },
     "mimic-fn": {
@@ -2085,7 +2085,7 @@
       "requires": {
         "execa": "1.0.0",
         "lcid": "2.0.0",
-        "mem": "4.0.0"
+        "mem": "4.1.0"
       }
     },
     "os-tmpdir": {
@@ -2105,9 +2105,9 @@
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-is-promise": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
-      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
+      "integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg=="
     },
     "p-limit": {
       "version": "1.3.0",
@@ -2736,7 +2736,7 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-7.1.0.tgz",
       "integrity": "sha512-lbk82UOIGuCEsZhPj8rNAkXSDXd6p0QLzIuSsCdxrqnqU56St4eyOB+AlXsVgVeRmetPTYydIuvFfpDIed8mqw==",
       "requires": {
-        "@types/unist": "2.0.2",
+        "@types/unist": "2.0.3",
         "@types/vfile": "3.0.2",
         "bail": "1.0.3",
         "extend": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint './**/*.js'"
   },
   "dependencies": {
-    "@quilicicf/markdown-formatter": "1.0.0"
+    "@quilicicf/markdown-formatter": "2.0.1"
   },
   "devDependencies": {
     "@talend/eslint-config": "2.0.1",


### PR DESCRIPTION
## What is this PR solving

This PR relocates the cursor in the formatted content better. 

It also uses the buffer's `setTextViaDiff` for better performance. 

## How does it solve it

Upgrades `@quilicicf/markdown-formatter` to use a version that computes the new cursor position better.